### PR TITLE
add setup instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 statusbot
 =========
+
+## setup
+
+1. copy `config.sample.php` to `config.php`
+2. create a monitor-specific API key at uptimerobot.com
+3. copy this key (starts with `m`) and replace `API_KEY` in a line that looks like this:
+  ```
+  'apiKey' => 'API_KEY',
+  ```


### PR DESCRIPTION
I created an API key for the account first, which didn't work, then a monitor key, which did. Figured a README was in order.
